### PR TITLE
Out of bounds error on ROI selection

### DIFF
--- a/MUedit_exported.m
+++ b/MUedit_exported.m
@@ -234,6 +234,11 @@ classdef MUedit_exported < matlab.apps.AppBase
                     app.EditField.Value = ['EMG amplitude for 50% of the EMG channels - Select the window #' num2str(nwin)];
                     app.roi = drawrectangle(app.UIAxes_Decomp_2);
                     x = [app.roi.Position(1) app.roi.Position(1) + app.roi.Position(3)];
+                    data_length = size(signal.data,2);
+                    % the second value of x can potentially be greater than
+                    % the length of the data matrix, therefore limit x(2)
+                    % to the data, e.g.:
+                    x(2) = min([x(2) data_length]);
                     signalprocess.coordinatesplateau(nwin*2-1) = floor(x(1));
                     signalprocess.coordinatesplateau(nwin*2) = floor(x(2));
                     for i = 1:signal.ngrid


### PR DESCRIPTION
Hello Dr. Avrillon (@simonavrillon),

This project is great. I'm excited to continue to use it in EMG unit processing. I'm especially glad for the very thorough user's manual. It was a breeze to get this set up for my work.

My particular use case for the software involves selecting essentially the entire epoch of recorded data, and during the ROI selection phase of data importing I noticed that I either need to be very precise or, more realistically, implement a limit on the ROI based on the length of the data. Please see the changes in this pull request for one potential fix.

Feel free to dismiss it or implement the changes, I just wanted to inform you. I think it might be nice to have a "Use entire timeseries" toggle in the menu. I'd be happy to implement that if you think it would be useful.

Thank you for your work,
J. Gilmer
